### PR TITLE
Feature/melodic upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   geometry_msgs
   sensor_msgs
+  message_filters
 )
 
 add_message_files(DIRECTORY msg)
@@ -23,6 +24,10 @@ add_definitions("-std=c++0x -Wall -Werror")
 add_executable(${PROJECT_NAME} src/imu_3dm_gx4.cpp src/imu.cpp)
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
+)
+
+add_executable(merge_imu_filter src/merge_imu_filter.cpp)
+target_link_libraries(merge_imu_filter  ${catkin_LIBRARIES}
 )
 
 add_dependencies(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,24 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.3)
 project(imu_3dm_gx4)
-find_package(catkin REQUIRED COMPONENTS
-  diagnostic_updater
-  message_generation
-  roscpp
-  geometry_msgs
-  sensor_msgs
-)
+
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(catkin REQUIRED
+             COMPONENTS tf2_ros
+                        roscpp
+                        geometry_msgs
+                        sensor_msgs
+                        diagnostic_updater
+                        message_generation)
 
 add_message_files(DIRECTORY msg)
 generate_messages(DEPENDENCIES geometry_msgs)
 
-catkin_package(
-  CATKIN_DEPENDS message_runtime geometry_msgs sensor_msgs)
-
-# include boost
-find_package(Boost REQUIRED)
-include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
-
-add_definitions("-std=c++0x -Wall -Werror")
+catkin_package(CATKIN_DEPENDS message_runtime geometry_msgs sensor_msgs)
 
 add_executable(${PROJECT_NAME} src/imu_3dm_gx4.cpp src/imu.cpp)
-target_link_libraries(${PROJECT_NAME}
-  ${catkin_LIBRARIES}
-)
+target_include_directories(${PROJECT_NAME} PRIVATE ${catkin_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${catkin_LIBRARIES})
 
-add_dependencies(${PROJECT_NAME}
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
-)
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS}
+                 ${catkin_EXPORTED_TARGETS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,13 @@ project(imu_3dm_gx4)
 set(CMAKE_CXX_STANDARD 11)
 
 find_package(catkin REQUIRED
-             COMPONENTS tf2_ros
+             COMPONENTS 
+
                         roscpp
-                        geometry_msgs
+                        tf2_ros
+                        std_msgs
                         sensor_msgs
+                        geometry_msgs
                         diagnostic_updater
                         message_generation)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,27 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.3)
 project(imu_3dm_gx4)
-find_package(catkin REQUIRED COMPONENTS
-  diagnostic_updater
-  message_generation
-  roscpp
-  geometry_msgs
-  sensor_msgs
-)
+
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(catkin REQUIRED
+             COMPONENTS 
+
+                        roscpp
+                        tf2_ros
+                        std_msgs
+                        sensor_msgs
+                        geometry_msgs
+                        diagnostic_updater
+                        message_generation)
 
 add_message_files(DIRECTORY msg)
 generate_messages(DEPENDENCIES geometry_msgs)
 
-catkin_package(
-  CATKIN_DEPENDS message_runtime geometry_msgs sensor_msgs)
-
-# include boost
-find_package(Boost REQUIRED)
-include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
-
-add_definitions("-std=c++0x -Wall -Werror")
+catkin_package(CATKIN_DEPENDS message_runtime geometry_msgs sensor_msgs)
 
 add_executable(${PROJECT_NAME} src/imu_3dm_gx4.cpp src/imu.cpp)
-target_link_libraries(${PROJECT_NAME}
-  ${catkin_LIBRARIES}
-)
+target_include_directories(${PROJECT_NAME} PRIVATE ${catkin_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${catkin_LIBRARIES})
 
-add_dependencies(${PROJECT_NAME}
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
-)
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS}
+                 ${catkin_EXPORTED_TARGETS})

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 The `imu_3dm_gx4` package provides support for the [Lord Corporation](http://www.microstrain.com) Microstrain [3DM-GX4](http://www.microstrain.com/inertial) series IMU. The package employs the MIP packet format, so it could conceivably be adapted to support other versions of Microstrain products with relatively little effort. At present, the 45 series is not supported.
 
-This package works on Ubuntu 12.04, 14.04 and 16.04.
+This package works on Ubuntu 16.04 and 18.04.
 
 ## Version History
 
@@ -45,6 +45,7 @@ The following additional options are present for leveraging the 3DM's onboard es
 * `filter_rate`: Filter rate to use, in Hz. Default is 100.
 * `enable_mag_update`: If true, the IMU will use the magnetometer to correct the heading angle estimate. Default is false.
 * `enable_accel_update`: If true, the IMU will use the accelerometer to correct
+
 the roll/pitch angle estimates. Default is true.
 
 **In order to launch the node** (streaming IMU data at 100Hz), execute:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This package works on Ubuntu 16.04 and 18.04.
 ## Options
 
 The `imu_3dm_gx4` node supports the following base options:
-* `device`: Path to the device in `/dev`. Defaults to `/dev/ttyACM0`.
+* `device`: Path to the device in `/dev`. Defaults to `/dev/imu`.
 * `baudrate`: Baudrate to employ with serial communication. Defaults to `115200`.
 * `frame_id`: Frame to use in headers.
 * `imu_rate`: IMU rate to use, in Hz. Default is 100.

--- a/calib/imu_3dm_gx4_25.yaml
+++ b/calib/imu_3dm_gx4_25.yaml
@@ -1,5 +1,5 @@
 #Accelerometers
-accelerometer_noise_density: 1.0e-03  #Noise density (continuous-time)
+accelerometer_noise_density: 1.0e-04  #Noise density (continuous-time)
 accelerometer_random_walk:   0.039e-02 #Bias random walk
 
 #Gyroscopes
@@ -7,5 +7,5 @@ gyroscope_noise_density:     8.73e-05 #Noise density (continuous-time)
 gyroscope_random_walk:       4.8e-05  #Bias random walk
 
 update_rate:                 200.0 #Hz (for discretization of the values above)
-rostopic:                    /imu_3dm_gx4/imu
+rostopic:                    /imu/imu
 

--- a/calib/imu_3dm_gx4_25_noise.yaml
+++ b/calib/imu_3dm_gx4_25_noise.yaml
@@ -1,0 +1,12 @@
+accelerometer:
+  noise_density: 1.0e-04 # m/s^2/sqrt(Hz)
+  bias_instability: 0.039e-02 # m/s^3/sqrt(Hz)
+  initial_bias_error: 0.0196 # m/s^2
+
+gyroscope:
+  noise_density: 8.73e-05 # rad/s/sqrt(Hz)
+  bias_instability: 4.8e-05 # rad/s^2/sqrt(Hz)
+  initial_bias_error: 0.00087 # rad/s
+
+magnetometer:
+  noise_density: 0.0001 # Gauss/sqrt(Hz)

--- a/launch/imu.launch
+++ b/launch/imu.launch
@@ -41,6 +41,7 @@
         <param name="verbose" type="bool" value="$(arg verbose)"/>
         <param name="baudrate" type="int" value="$(arg baudrate)" />
         <param name="frame_id" type="string" value="$(arg frame_id)"/>
+        <param name="gravity" type="double" value="$(arg gravity)"/>
         <param name="fixed_frame_id" type="string" value="$(arg fixed_frame_id)"/>
         <param name="imu_rate" type="int" value="$(arg imu_rate)" />
         <param name="filter_rate" type="int" value="$(arg filter_rate)"/>

--- a/launch/imu.launch
+++ b/launch/imu.launch
@@ -4,36 +4,44 @@
     <arg name="imu" default="imu"/>
 
     <!-- IMU Settings -->
-    <arg name="device" default="/dev/ttyACM0" />
+    <arg name="device" default="/dev/ttyACM0"/>
+
+    <!-- local gravity (philadelphia) -->
+    <arg name="gravity" default="9.81627"/>
 
     <!-- Verbose logging -->
     <arg name="verbose" default="false"/>
 
     <!-- Frame ID for messages -->
     <arg name="frame_id" default="$(arg imu)"/>
+    <arg name="fixed_frame_id" default="world"/>
 
     <!-- Baudrate of serial comms (see manual for allowed values) -->
     <arg name="baudrate" default="115200"/>
 
     <!-- Data rate in Hz -->
     <arg name="imu_rate" default="100"/>
-    <arg name="filter_rate" default="100"/>
+    <arg name="filter_rate" default="$(arg imu_rate)"/>
 
     <!-- Enable/Disable the magnetometer -->
     <arg name="enable_magnetometer" default="true"/>
 
     <!-- Enable/Disable the filter -->
-    <arg name="enable_filter" default="false"/>
+    <arg name="enable_filter" default="true"/>
 
     <!-- Enable/Disable filter updates -->
-    <arg name="enable_accel_update" default="false"/>
+    <arg name="enable_accel_update" default="true"/>
     <arg name="enable_mag_update" default="false"/>
+
+    <!-- Publish transform when filter is enabled -->
+    <arg name="enable_tf" default="$(arg enable_filter)"/>
 
     <node pkg="imu_3dm_gx4" name="$(arg imu)" type="imu_3dm_gx4" output="$(arg output)">
         <param name="device" type="string" value="$(arg device)" />
         <param name="verbose" type="bool" value="$(arg verbose)"/>
         <param name="baudrate" type="int" value="$(arg baudrate)" />
         <param name="frame_id" type="string" value="$(arg frame_id)"/>
+        <param name="fixed_frame_id" type="string" value="$(arg fixed_frame_id)"/>
         <param name="imu_rate" type="int" value="$(arg imu_rate)" />
         <param name="filter_rate" type="int" value="$(arg filter_rate)"/>
         <param name="enable_magnetometer" type="bool" value="$(arg enable_magnetometer)"/>

--- a/launch/imu.launch
+++ b/launch/imu.launch
@@ -4,7 +4,7 @@
     <arg name="imu" default="imu"/>
 
     <!-- IMU Settings -->
-    <arg name="device" default="/dev/ttyACM0"/>
+    <arg name="device" default="/dev/imu"/>
 
     <!-- local gravity (philadelphia) -->
     <arg name="gravity" default="9.81627"/>

--- a/launch/imu.launch
+++ b/launch/imu.launch
@@ -4,36 +4,45 @@
     <arg name="imu" default="imu"/>
 
     <!-- IMU Settings -->
-    <arg name="device" default="/dev/ttyACM0" />
+    <arg name="device" default="/dev/ttyACM0"/>
+
+    <!-- local gravity (philadelphia) -->
+    <arg name="gravity" default="9.81627"/>
 
     <!-- Verbose logging -->
     <arg name="verbose" default="false"/>
 
     <!-- Frame ID for messages -->
     <arg name="frame_id" default="$(arg imu)"/>
+    <arg name="fixed_frame_id" default="world"/>
 
     <!-- Baudrate of serial comms (see manual for allowed values) -->
     <arg name="baudrate" default="115200"/>
 
     <!-- Data rate in Hz -->
     <arg name="imu_rate" default="100"/>
-    <arg name="filter_rate" default="100"/>
+    <arg name="filter_rate" default="$(arg imu_rate)"/>
 
     <!-- Enable/Disable the magnetometer -->
     <arg name="enable_magnetometer" default="true"/>
 
     <!-- Enable/Disable the filter -->
-    <arg name="enable_filter" default="false"/>
+    <arg name="enable_filter" default="true"/>
 
     <!-- Enable/Disable filter updates -->
-    <arg name="enable_accel_update" default="false"/>
+    <arg name="enable_accel_update" default="true"/>
     <arg name="enable_mag_update" default="false"/>
+
+    <!-- Publish transform when filter is enabled -->
+    <arg name="enable_tf" default="$(arg enable_filter)"/>
 
     <node pkg="imu_3dm_gx4" name="$(arg imu)" type="imu_3dm_gx4" output="$(arg output)">
         <param name="device" type="string" value="$(arg device)" />
         <param name="verbose" type="bool" value="$(arg verbose)"/>
         <param name="baudrate" type="int" value="$(arg baudrate)" />
         <param name="frame_id" type="string" value="$(arg frame_id)"/>
+        <param name="gravity" type="double" value="$(arg gravity)"/>
+        <param name="fixed_frame_id" type="string" value="$(arg fixed_frame_id)"/>
         <param name="imu_rate" type="int" value="$(arg imu_rate)" />
         <param name="filter_rate" type="int" value="$(arg filter_rate)"/>
         <param name="enable_magnetometer" type="bool" value="$(arg enable_magnetometer)"/>

--- a/launch/imu.rviz
+++ b/launch/imu.rviz
@@ -1,0 +1,158 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /Pose1
+      Splitter Ratio: 0.5
+    Tree Height: 704
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/Axes
+      Enabled: false
+      Length: 2
+      Name: Axes
+      Radius: 0.009999999776482582
+      Reference Frame: <Fixed Frame>
+      Value: false
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        imu:
+          Value: true
+        world:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        world:
+          imu:
+            {}
+      Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.10000000149011612
+      Class: rviz/Pose
+      Color: 255; 25; 0
+      Enabled: false
+      Head Length: 0.30000001192092896
+      Head Radius: 0.10000000149011612
+      Name: Pose
+      Shaft Length: 1
+      Shaft Radius: 0.05000000074505806
+      Shape: Arrow
+      Topic: /imu/pose
+      Unreliable: false
+      Value: false
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 1.3153131008148193
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: false
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.7503980398178101
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 2.8053975105285645
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1001
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001560000034bfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000034b000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f0000034bfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d0000034b000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000003efc0100000002fb0000000800540069006d0065010000000000000780000002eb00fffffffb0000000800540069006d006501000000000000045000000000000000000000050f0000034b00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1920
+  X: 1920
+  Y: 0

--- a/launch/imu.rviz
+++ b/launch/imu.rviz
@@ -133,10 +133,10 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.6003981828689575
+      Pitch: 0.7503980398178101
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 1.705397367477417
+      Yaw: 2.8053975105285645
     Saved: ~
 Window Geometry:
   Displays:

--- a/launch/imu.rviz
+++ b/launch/imu.rviz
@@ -1,0 +1,158 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /Pose1
+      Splitter Ratio: 0.5
+    Tree Height: 704
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/Axes
+      Enabled: false
+      Length: 2
+      Name: Axes
+      Radius: 0.009999999776482582
+      Reference Frame: <Fixed Frame>
+      Value: false
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        imu:
+          Value: true
+        world:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        world:
+          imu:
+            {}
+      Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.10000000149011612
+      Class: rviz/Pose
+      Color: 255; 25; 0
+      Enabled: false
+      Head Length: 0.30000001192092896
+      Head Radius: 0.10000000149011612
+      Name: Pose
+      Shaft Length: 1
+      Shaft Radius: 0.05000000074505806
+      Shape: Arrow
+      Topic: /imu/pose
+      Unreliable: false
+      Value: false
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 1.3153131008148193
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: false
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.6003981828689575
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 1.705397367477417
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1001
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001560000034bfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000034b000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f0000034bfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d0000034b000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000003efc0100000002fb0000000800540069006d0065010000000000000780000002eb00fffffffb0000000800540069006d006501000000000000045000000000000000000000050f0000034b00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1920
+  X: 1920
+  Y: 0

--- a/launch/merge.launch
+++ b/launch/merge.launch
@@ -1,0 +1,5 @@
+<launch>
+  <node pkg="imu_3dm_gx4" name="merge_imu_filter" type="merge_imu_filter"
+    output="screen" ns="imu">
+  </node>
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,6 @@
   <version>0.0.5</version>
   <description>Driver for Microstrain 3DM-GX4-25 IMU</description>
 
-  <maintainer email="gcross.code@icloud.com">gcross</maintainer>
   <maintainer email="kartikmohta@gmail.com">Kartik Mohta</maintainer>
 
   <author>Gareth Cross</author>

--- a/package.xml
+++ b/package.xml
@@ -14,10 +14,11 @@
   <build_depend>message_generation</build_depend>
   <exec_depend>message_runtime</exec_depend>
 
-  <depend>diagnostic_updater</depend>
-  <depend>geometry_msgs</depend>
   <depend>roscpp</depend>
+  <depend>tf2_ros</depend>
   <depend>sensor_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>diagnostic_updater</depend>
 
   <export>
   </export>

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,6 @@
   <version>0.0.5</version>
   <description>Driver for Microstrain 3DM-GX4-25 IMU</description>
 
-  <maintainer email="gcross.code@icloud.com">gcross</maintainer>
   <maintainer email="kartikmohta@gmail.com">Kartik Mohta</maintainer>
 
   <author>Gareth Cross</author>
@@ -15,10 +14,11 @@
   <build_depend>message_generation</build_depend>
   <exec_depend>message_runtime</exec_depend>
 
-  <depend>diagnostic_updater</depend>
-  <depend>geometry_msgs</depend>
   <depend>roscpp</depend>
+  <depend>tf2_ros</depend>
   <depend>sensor_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>diagnostic_updater</depend>
 
   <export>
   </export>

--- a/script/add_rule
+++ b/script/add_rule
@@ -1,23 +1,17 @@
 #!/bin/bash
 
-
-if [[ $UID != 0 ]]; then
-	echo "Please start the script as root or sudo!"
-	exit 1
-fi
-
-read -p "This will add $SUDO_USER to group imu are you sure? y/n: " -n 1 -r
+read -p "This will add $USER to group imu are you sure? y/n: " -n 1 -r
 echo #newline
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
 	# add group and user
-	groupadd imu
-	adduser $SUDO_USER imu
+	sudo groupadd imu
+	sudo adduser $USER imu
 
 	# addudev rule
 	DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # get directory where this script is stored
-	cp $DIR/imu_3dm_gx4.rules /etc/udev/rules.d/
+	sudo cp $DIR/imu_3dm_gx4.rules /etc/udev/rules.d/
 
 	#reload udev
-	udevadm control --reload-rules
+	sudo udevadm control --reload-rules
 fi

--- a/script/imu_3dm_gx4.rules
+++ b/script/imu_3dm_gx4.rules
@@ -1,1 +1,1 @@
-SUBSYSTEMS=="usb", ATTRS{manufacturer}=="Lord Microstrain",ATTRS{product}=="Lord Inertial Sensor", MODE="0777", GROUP="imu"
+SUBSYSTEM=="tty", ATTRS{manufacturer}=="Lord Microstrain",ATTRS{product}=="Lord Inertial Sensor", MODE="0777", GROUP="imu", SYMLINK+="imu"

--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -20,6 +20,7 @@
 #include <stdexcept>
 #include <boost/assert.hpp>
 
+
 extern "C" {
 #include <fcntl.h>
 #include <getopt.h>

--- a/src/imu.hpp
+++ b/src/imu.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include <bitset>
 #include <map>
+#include <functional>
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ //  will fail outside of gcc/clang
 #define HOST_LITTLE_ENDIAN

--- a/src/imu.hpp
+++ b/src/imu.hpp
@@ -243,7 +243,7 @@ public:
 
   /**
    * @brief Imu Constructor
-   * @param device Path to the device in /dev, eg. /dev/ttyACM0
+   * @param device Path to the device in /dev, eg. /dev/imu
    * @param verbose If true, packet reads are logged to console.
    */
   Imu(const std::string &device, bool verbose);

--- a/src/imu_3dm_gx4.cpp
+++ b/src/imu_3dm_gx4.cpp
@@ -1,13 +1,16 @@
-#include <ros/ros.h>
-#include <ros/node_handle.h>
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <diagnostic_updater/publisher.h>
+#include <ros/node_handle.h>
+#include <ros/ros.h>
 
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/QuaternionStamped.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <geometry_msgs/Vector3Stamped.h>
+#include <sensor_msgs/FluidPressure.h>
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/MagneticField.h>
-#include <sensor_msgs/FluidPressure.h>
-#include <geometry_msgs/Vector3Stamped.h>
-#include <geometry_msgs/QuaternionStamped.h>
+#include <tf2_ros/transform_broadcaster.h>
 
 #include <imu_3dm_gx4/FilterOutput.h>
 #include "imu.hpp"
@@ -20,18 +23,21 @@ ros::Publisher pubIMU;
 ros::Publisher pubMag;
 ros::Publisher pubPressure;
 ros::Publisher pubFilter;
+ros::Publisher pubPose;
 std::string frameId;
+std::string fixeFrameId;
 
 Imu::Info info;
 Imu::DiagnosticFields fields;
 bool enableMagnetometer;
+bool enableTf;
 
 //  diagnostic_updater resources
 std::shared_ptr<diagnostic_updater::Updater> updater;
 std::shared_ptr<diagnostic_updater::TopicDiagnostic> imuDiag;
 std::shared_ptr<diagnostic_updater::TopicDiagnostic> filterDiag;
 
-void publishData(const Imu::IMUData &data) {
+void publishData(const Imu::IMUData& data) {
   sensor_msgs::Imu imu;
   sensor_msgs::MagneticField field;
   sensor_msgs::FluidPressure pressure;
@@ -57,7 +63,7 @@ void publishData(const Imu::IMUData &data) {
   }
 
   imu.orientation_covariance[0] =
-      -1; //  orientation data is on a separate topic
+      -1;  //  orientation data is on a separate topic
 
   imu.linear_acceleration.x = data.accel[0] * kEarthGravity;
   imu.linear_acceleration.y = data.accel[1] * kEarthGravity;
@@ -85,12 +91,14 @@ void publishData(const Imu::IMUData &data) {
   }
 }
 
-void publishFilter(const Imu::FilterData &data) {
+void publishFilter(const Imu::FilterData& data) {
   assert(data.fields & Imu::FilterData::Quaternion);
   assert(data.fields & Imu::FilterData::Bias);
   assert(data.fields & Imu::FilterData::AngleUnertainty);
   assert(data.fields & Imu::FilterData::BiasUncertainty);
-  
+
+  static tf2_ros::TransformBroadcaster br;
+
   imu_3dm_gx4::FilterOutput output;
   output.header.stamp = ros::Time::now();
   output.header.frame_id = frameId;
@@ -102,38 +110,51 @@ void publishFilter(const Imu::FilterData &data) {
   output.bias.y = data.bias[1];
   output.bias.z = data.bias[2];
 
-  output.bias_covariance[0] = data.biasUncertainty[0]*data.biasUncertainty[0];
-  output.bias_covariance[4] = data.biasUncertainty[1]*data.biasUncertainty[1];
-  output.bias_covariance[8] = data.biasUncertainty[2]*data.biasUncertainty[2];
-  
-  output.orientation_covariance[0] = data.angleUncertainty[0]*
-      data.angleUncertainty[0];
-  output.orientation_covariance[4] = data.angleUncertainty[1]*
-      data.angleUncertainty[1];
-  output.orientation_covariance[8] = data.angleUncertainty[2]*
-      data.angleUncertainty[2];
-  
+  output.bias_covariance[0] = data.biasUncertainty[0] * data.biasUncertainty[0];
+  output.bias_covariance[4] = data.biasUncertainty[1] * data.biasUncertainty[1];
+  output.bias_covariance[8] = data.biasUncertainty[2] * data.biasUncertainty[2];
+
+  output.orientation_covariance[0] =
+      data.angleUncertainty[0] * data.angleUncertainty[0];
+  output.orientation_covariance[4] =
+      data.angleUncertainty[1] * data.angleUncertainty[1];
+  output.orientation_covariance[8] =
+      data.angleUncertainty[2] * data.angleUncertainty[2];
+
   output.quat_status = data.quaternionStatus;
   output.bias_status = data.biasStatus;
   output.orientation_covariance_status = data.angleUncertaintyStatus;
   output.bias_covariance_status = data.biasUncertaintyStatus;
-  
+
   pubFilter.publish(output);
+
+  if (enableTf) {
+    geometry_msgs::TransformStamped tf_msg;
+    tf_msg.header.stamp = output.header.stamp;
+    tf_msg.header.frame_id = fixeFrameId;
+    tf_msg.child_frame_id = output.header.frame_id;
+    tf_msg.transform.rotation = output.orientation;
+    br.sendTransform(tf_msg);
+
+    geometry_msgs::PoseStamped pose_msg;
+    pose_msg.header = tf_msg.header;
+    pose_msg.pose.orientation = tf_msg.transform.rotation;
+    pubPose.publish(pose_msg);
+  }
+
   if (filterDiag) {
     filterDiag->tick(output.header.stamp);
   }
 }
 
 std::shared_ptr<diagnostic_updater::TopicDiagnostic> configTopicDiagnostic(
-    const std::string& name, double * target) {
+    const std::string& name, double* target) {
   std::shared_ptr<diagnostic_updater::TopicDiagnostic> diag;
   const double period = 1.0 / *target;  //  for 1000Hz, period is 1e-3
-  
+
   diagnostic_updater::FrequencyStatusParam freqParam(target, target, 0.01, 10);
   diagnostic_updater::TimeStampStatusParam timeParam(0, period * 0.5);
-  diag.reset(new diagnostic_updater::TopicDiagnostic(name, 
-                                                     *updater, 
-                                                     freqParam,
+  diag.reset(new diagnostic_updater::TopicDiagnostic(name, *updater, freqParam,
                                                      timeParam));
   return diag;
 }
@@ -141,30 +162,30 @@ std::shared_ptr<diagnostic_updater::TopicDiagnostic> configTopicDiagnostic(
 void updateDiagnosticInfo(diagnostic_updater::DiagnosticStatusWrapper& stat,
                           imu_3dm_gx4::Imu* imu) {
   //  add base device info
-  std::map<std::string,std::string> map = info.toMap();
-  for (const std::pair<std::string,std::string>& p : map) {
+  std::map<std::string, std::string> map = info.toMap();
+  for (const std::pair<std::string, std::string>& p : map) {
     stat.add(p.first, p.second);
   }
-  
+
   try {
     //  try to read diagnostic info
     imu->getDiagnosticInfo(fields, info);
-    
+
     auto map = fields.toMap();
     for (const std::pair<std::string, unsigned int>& p : map) {
       stat.add(p.first, p.second);
     }
-    stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "Read diagnostic info.");
-  }
-  catch (std::exception& e) {
+    stat.summary(diagnostic_msgs::DiagnosticStatus::OK,
+                 "Read diagnostic info.");
+  } catch (std::exception& e) {
     const std::string message = std::string("Failed: ") + e.what();
     stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, message);
   }
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ros::init(argc, argv, "imu_3dm_gx4");
-  ros::NodeHandle nh("~");
+  ros::NodeHandle pnh("~");
 
   std::string device;
   int baudrate;
@@ -172,32 +193,40 @@ int main(int argc, char **argv) {
   bool enableMagUpdate, enableAccelUpdate;
   int requestedImuRate, requestedFilterRate;
   bool verbose;
-  
+
   //  load parameters from launch file
-  nh.param<std::string>("device", device, "/dev/ttyACM0");
-  nh.param<int>("baudrate", baudrate, 115200);
-  nh.param<std::string>("frame_id", frameId, std::string("imu"));
-  nh.param<int>("imu_rate", requestedImuRate, 100);
-  nh.param<int>("filter_rate", requestedFilterRate, 100);
-  nh.param<bool>("enable_magnetometer", enableMagnetometer, true);
-  nh.param<bool>("enable_filter", enableFilter, false);
-  nh.param<bool>("enable_mag_update", enableMagUpdate, false);
-  nh.param<bool>("enable_accel_update", enableAccelUpdate, true);
-  nh.param<bool>("verbose", verbose, false);
-  
+  pnh.param<std::string>("device", device, "/dev/ttyACM0");
+  pnh.param<int>("baudrate", baudrate, 115200);
+  pnh.param<std::string>("frame_id", frameId, "imu");
+  pnh.param<std::string>("fixed_frame_id", fixeFrameId, "world");
+  pnh.param<int>("imu_rate", requestedImuRate, 100);
+  pnh.param<int>("filter_rate", requestedFilterRate, 100);
+  pnh.param<bool>("enable_magnetometer", enableMagnetometer, true);
+  pnh.param<bool>("enable_filter", enableFilter, false);
+  pnh.param<bool>("enable_mag_update", enableMagUpdate, false);
+  pnh.param<bool>("enable_accel_update", enableAccelUpdate, true);
+  pnh.param<bool>("enable_tf", enableTf, enableFilter);
+  pnh.param<bool>("verbose", verbose, false);
+
   if (requestedFilterRate < 0 || requestedImuRate < 0) {
     ROS_ERROR("imu_rate and filter_rate must be > 0");
     return -1;
   }
-  
-  pubIMU = nh.advertise<sensor_msgs::Imu>("imu", 1);
-  pubPressure = nh.advertise<sensor_msgs::FluidPressure>("pressure", 1);
+
+  pubIMU = pnh.advertise<sensor_msgs::Imu>("imu", 1);
+  pubPressure = pnh.advertise<sensor_msgs::FluidPressure>("pressure", 1);
 
   if (enableMagnetometer) {
-    pubMag = nh.advertise<sensor_msgs::MagneticField>("magnetic_field", 1);
+    pubMag = pnh.advertise<sensor_msgs::MagneticField>("magnetic_field", 1);
+    ROS_INFO("Publish magnetic field to %s", pubMag.getTopic().c_str());
   }
   if (enableFilter) {
-    pubFilter = nh.advertise<imu_3dm_gx4::FilterOutput>("filter", 1);
+    pubFilter = pnh.advertise<imu_3dm_gx4::FilterOutput>("filter", 1);
+    ROS_INFO("Publish filter to %s", pubFilter.getTopic().c_str());
+  }
+  if (enableTf) {
+    pubPose = pnh.advertise<geometry_msgs::PoseStamped>("pose", 1);
+    ROS_INFO("Publish pose to %s", pubPose.getTopic().c_str());
   }
 
   //  new instance of the IMU
@@ -210,8 +239,8 @@ int main(int argc, char **argv) {
 
     ROS_INFO("Fetching device info.");
     imu.getDeviceInfo(info);
-    std::map<std::string,std::string> map = info.toMap();
-    for (const std::pair<std::string,std::string>& p : map) {
+    std::map<std::string, std::string> map = info.toMap();
+    for (const std::pair<std::string, std::string>& p : map) {
       ROS_INFO("\t%s: %s", p.first.c_str(), p.second.c_str());
     }
 
@@ -227,37 +256,34 @@ int main(int argc, char **argv) {
 
     //  calculate decimation rates
     if (static_cast<uint16_t>(requestedImuRate) > imuBaseRate) {
-      throw std::runtime_error("imu_rate cannot exceed " + 
+      throw std::runtime_error("imu_rate cannot exceed " +
                                std::to_string(imuBaseRate));
     }
     if (static_cast<uint16_t>(requestedFilterRate) > filterBaseRate) {
-      throw std::runtime_error("filter_rate cannot exceed " + 
+      throw std::runtime_error("filter_rate cannot exceed " +
                                std::to_string(filterBaseRate));
     }
-    
+
     const uint16_t imuDecimation = imuBaseRate / requestedImuRate;
     const uint16_t filterDecimation = filterBaseRate / requestedFilterRate;
-    
+
     ROS_INFO("Selecting IMU decimation: %u", imuDecimation);
     std::bitset<4> imuSources = Imu::IMUData::Accelerometer |
                                 Imu::IMUData::Gyroscope |
                                 Imu::IMUData::Barometer;
-    if (enableMagnetometer)
-    {
+    if (enableMagnetometer) {
       ROS_INFO("Enabling magnetometer");
       imuSources |= Imu::IMUData::Magnetometer;
-    }
-    else
-    {
+    } else {
       ROS_INFO("Disabling magnetometer");
     }
     imu.setIMUDataRate(imuDecimation, imuSources);
 
     ROS_INFO("Selecting filter decimation: %u", filterDecimation);
-    imu.setFilterDataRate(filterDecimation, Imu::FilterData::Quaternion |
-                          Imu::FilterData::Bias |
-                          Imu::FilterData::AngleUnertainty |
-                          Imu::FilterData::BiasUncertainty);
+    imu.setFilterDataRate(filterDecimation,
+                          Imu::FilterData::Quaternion | Imu::FilterData::Bias |
+                              Imu::FilterData::AngleUnertainty |
+                              Imu::FilterData::BiasUncertainty);
 
     ROS_INFO("Enabling IMU data stream");
     imu.enableIMUStream(true);
@@ -279,25 +305,25 @@ int main(int argc, char **argv) {
     imu.setFilterDataCallback(publishFilter);
 
     //  configure diagnostic updater
-    if (!nh.hasParam("diagnostic_period")) {
-      nh.setParam("diagnostic_period", 0.2);  //  5hz period
+    if (!pnh.hasParam("diagnostic_period")) {
+      pnh.setParam("diagnostic_period", 0.2);  //  5hz period
     }
-    
+
     updater.reset(new diagnostic_updater::Updater());
     const std::string hwId = info.modelName + "-" + info.modelNumber;
     updater->setHardwareID(hwId);
-    
+
     //  calculate the actual rates we will get
     double imuRate = imuBaseRate / (1.0 * imuDecimation);
     double filterRate = filterBaseRate / (1.0 * filterDecimation);
-    imuDiag = configTopicDiagnostic("imu",&imuRate);
+    imuDiag = configTopicDiagnostic("imu", &imuRate);
     if (enableFilter) {
-      filterDiag = configTopicDiagnostic("filter",&filterRate);
+      filterDiag = configTopicDiagnostic("filter", &filterRate);
     }
-    
-    updater->add("diagnostic_info", 
+
+    updater->add("diagnostic_info",
                  boost::bind(&updateDiagnosticInfo, _1, &imu));
-    
+
     ROS_INFO("Resuming the device");
     imu.resume();
 
@@ -306,16 +332,11 @@ int main(int argc, char **argv) {
       updater->update();
     }
     imu.disconnect();
-  }
-  catch (Imu::io_error &e) {
+  } catch (Imu::io_error& e) {
     ROS_ERROR("IO error: %s\n", e.what());
-  }
-  catch (Imu::timeout_error &e) {
+  } catch (Imu::timeout_error& e) {
     ROS_ERROR("Timeout: %s\n", e.what());
-  }
-  catch (std::exception &e) {
+  } catch (std::exception& e) {
     ROS_ERROR("Exception: %s\n", e.what());
   }
-
-  return 0;
 }

--- a/src/imu_3dm_gx4.cpp
+++ b/src/imu_3dm_gx4.cpp
@@ -17,7 +17,7 @@
 
 using namespace imu_3dm_gx4;
 
-#define kEarthGravity (9.80665)
+double gravity;
 
 ros::Publisher pubIMU;
 ros::Publisher pubMag;
@@ -65,9 +65,9 @@ void publishData(const Imu::IMUData& data) {
   imu.orientation_covariance[0] =
       -1;  //  orientation data is on a separate topic
 
-  imu.linear_acceleration.x = data.accel[0] * kEarthGravity;
-  imu.linear_acceleration.y = data.accel[1] * kEarthGravity;
-  imu.linear_acceleration.z = data.accel[2] * kEarthGravity;
+  imu.linear_acceleration.x = data.accel[0] * gravity;
+  imu.linear_acceleration.y = data.accel[1] * gravity;
+  imu.linear_acceleration.z = data.accel[2] * gravity;
   imu.angular_velocity.x = data.gyro[0];
   imu.angular_velocity.y = data.gyro[1];
   imu.angular_velocity.z = data.gyro[2];
@@ -199,6 +199,11 @@ int main(int argc, char** argv) {
   pnh.param<int>("baudrate", baudrate, 115200);
   pnh.param<std::string>("frame_id", frameId, "imu");
   pnh.param<std::string>("fixed_frame_id", fixeFrameId, "world");
+  pnh.param<double>("gravity", gravity, 0.0);
+  if (gravity <= 0.0) {
+    ROS_ERROR("Must set gravity value");
+    return -1;
+  }
   pnh.param<int>("imu_rate", requestedImuRate, 100);
   pnh.param<int>("filter_rate", requestedFilterRate, 100);
   pnh.param<bool>("enable_magnetometer", enableMagnetometer, true);

--- a/src/imu_3dm_gx4.cpp
+++ b/src/imu_3dm_gx4.cpp
@@ -198,7 +198,7 @@ int main(int argc, char** argv) {
   int retryAfter, maxRetries;
 
   //  load parameters from launch file
-  pnh.param<std::string>("device", device, "/dev/ttyACM0");
+  pnh.param<std::string>("device", device, "/dev/imu");
   pnh.param<int>("baudrate", baudrate, 115200);
   pnh.param<std::string>("frame_id", frameId, "imu");
   pnh.param<std::string>("fixed_frame_id", fixeFrameId, "world");

--- a/src/imu_3dm_gx4.cpp
+++ b/src/imu_3dm_gx4.cpp
@@ -1,37 +1,45 @@
-#include <ros/ros.h>
-#include <ros/node_handle.h>
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <diagnostic_updater/publisher.h>
+#include <ros/node_handle.h>
+#include <ros/ros.h>
 
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/QuaternionStamped.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <geometry_msgs/Vector3Stamped.h>
+#include <sensor_msgs/FluidPressure.h>
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/MagneticField.h>
-#include <sensor_msgs/FluidPressure.h>
-#include <geometry_msgs/Vector3Stamped.h>
-#include <geometry_msgs/QuaternionStamped.h>
+#include <std_msgs/Float64.h>
+#include <tf2_ros/transform_broadcaster.h>
 
 #include <imu_3dm_gx4/FilterOutput.h>
 #include "imu.hpp"
 
 using namespace imu_3dm_gx4;
 
-#define kEarthGravity (9.80665)
+double gravity;
 
 ros::Publisher pubIMU;
 ros::Publisher pubMag;
 ros::Publisher pubPressure;
 ros::Publisher pubFilter;
+ros::Publisher pubGravity;
+ros::Publisher pubPose;
 std::string frameId;
+std::string fixeFrameId;
 
 Imu::Info info;
 Imu::DiagnosticFields fields;
 bool enableMagnetometer;
+bool enableTf;
 
 //  diagnostic_updater resources
 std::shared_ptr<diagnostic_updater::Updater> updater;
 std::shared_ptr<diagnostic_updater::TopicDiagnostic> imuDiag;
 std::shared_ptr<diagnostic_updater::TopicDiagnostic> filterDiag;
 
-void publishData(const Imu::IMUData &data) {
+void publishData(const Imu::IMUData& data) {
   sensor_msgs::Imu imu;
   sensor_msgs::MagneticField field;
   sensor_msgs::FluidPressure pressure;
@@ -57,11 +65,11 @@ void publishData(const Imu::IMUData &data) {
   }
 
   imu.orientation_covariance[0] =
-      -1; //  orientation data is on a separate topic
+      -1;  //  orientation data is on a separate topic
 
-  imu.linear_acceleration.x = data.accel[0] * kEarthGravity;
-  imu.linear_acceleration.y = data.accel[1] * kEarthGravity;
-  imu.linear_acceleration.z = data.accel[2] * kEarthGravity;
+  imu.linear_acceleration.x = data.accel[0] * gravity;
+  imu.linear_acceleration.y = data.accel[1] * gravity;
+  imu.linear_acceleration.z = data.accel[2] * gravity;
   imu.angular_velocity.x = data.gyro[0];
   imu.angular_velocity.y = data.gyro[1];
   imu.angular_velocity.z = data.gyro[2];
@@ -85,12 +93,14 @@ void publishData(const Imu::IMUData &data) {
   }
 }
 
-void publishFilter(const Imu::FilterData &data) {
+void publishFilter(const Imu::FilterData& data) {
   assert(data.fields & Imu::FilterData::Quaternion);
   assert(data.fields & Imu::FilterData::Bias);
   assert(data.fields & Imu::FilterData::AngleUnertainty);
   assert(data.fields & Imu::FilterData::BiasUncertainty);
-  
+
+  static tf2_ros::TransformBroadcaster br;
+
   imu_3dm_gx4::FilterOutput output;
   output.header.stamp = ros::Time::now();
   output.header.frame_id = frameId;
@@ -102,38 +112,51 @@ void publishFilter(const Imu::FilterData &data) {
   output.bias.y = data.bias[1];
   output.bias.z = data.bias[2];
 
-  output.bias_covariance[0] = data.biasUncertainty[0]*data.biasUncertainty[0];
-  output.bias_covariance[4] = data.biasUncertainty[1]*data.biasUncertainty[1];
-  output.bias_covariance[8] = data.biasUncertainty[2]*data.biasUncertainty[2];
-  
-  output.orientation_covariance[0] = data.angleUncertainty[0]*
-      data.angleUncertainty[0];
-  output.orientation_covariance[4] = data.angleUncertainty[1]*
-      data.angleUncertainty[1];
-  output.orientation_covariance[8] = data.angleUncertainty[2]*
-      data.angleUncertainty[2];
-  
+  output.bias_covariance[0] = data.biasUncertainty[0] * data.biasUncertainty[0];
+  output.bias_covariance[4] = data.biasUncertainty[1] * data.biasUncertainty[1];
+  output.bias_covariance[8] = data.biasUncertainty[2] * data.biasUncertainty[2];
+
+  output.orientation_covariance[0] =
+      data.angleUncertainty[0] * data.angleUncertainty[0];
+  output.orientation_covariance[4] =
+      data.angleUncertainty[1] * data.angleUncertainty[1];
+  output.orientation_covariance[8] =
+      data.angleUncertainty[2] * data.angleUncertainty[2];
+
   output.quat_status = data.quaternionStatus;
   output.bias_status = data.biasStatus;
   output.orientation_covariance_status = data.angleUncertaintyStatus;
   output.bias_covariance_status = data.biasUncertaintyStatus;
-  
+
   pubFilter.publish(output);
+
+  if (enableTf) {
+    geometry_msgs::TransformStamped tf_msg;
+    tf_msg.header.stamp = output.header.stamp;
+    tf_msg.header.frame_id = fixeFrameId;
+    tf_msg.child_frame_id = output.header.frame_id + "_filter";
+    tf_msg.transform.rotation = output.orientation;
+    br.sendTransform(tf_msg);
+
+    geometry_msgs::PoseStamped pose_msg;
+    pose_msg.header = tf_msg.header;
+    pose_msg.pose.orientation = tf_msg.transform.rotation;
+    pubPose.publish(pose_msg);
+  }
+
   if (filterDiag) {
     filterDiag->tick(output.header.stamp);
   }
 }
 
 std::shared_ptr<diagnostic_updater::TopicDiagnostic> configTopicDiagnostic(
-    const std::string& name, double * target) {
+    const std::string& name, double* target) {
   std::shared_ptr<diagnostic_updater::TopicDiagnostic> diag;
   const double period = 1.0 / *target;  //  for 1000Hz, period is 1e-3
-  
+
   diagnostic_updater::FrequencyStatusParam freqParam(target, target, 0.01, 10);
   diagnostic_updater::TimeStampStatusParam timeParam(0, period * 0.5);
-  diag.reset(new diagnostic_updater::TopicDiagnostic(name, 
-                                                     *updater, 
-                                                     freqParam,
+  diag.reset(new diagnostic_updater::TopicDiagnostic(name, *updater, freqParam,
                                                      timeParam));
   return diag;
 }
@@ -141,30 +164,30 @@ std::shared_ptr<diagnostic_updater::TopicDiagnostic> configTopicDiagnostic(
 void updateDiagnosticInfo(diagnostic_updater::DiagnosticStatusWrapper& stat,
                           imu_3dm_gx4::Imu* imu) {
   //  add base device info
-  std::map<std::string,std::string> map = info.toMap();
-  for (const std::pair<std::string,std::string>& p : map) {
+  std::map<std::string, std::string> map = info.toMap();
+  for (const std::pair<std::string, std::string>& p : map) {
     stat.add(p.first, p.second);
   }
-  
+
   try {
     //  try to read diagnostic info
     imu->getDiagnosticInfo(fields, info);
-    
+
     auto map = fields.toMap();
     for (const std::pair<std::string, unsigned int>& p : map) {
       stat.add(p.first, p.second);
     }
-    stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "Read diagnostic info.");
-  }
-  catch (std::exception& e) {
+    stat.summary(diagnostic_msgs::DiagnosticStatus::OK,
+                 "Read diagnostic info.");
+  } catch (std::exception& e) {
     const std::string message = std::string("Failed: ") + e.what();
     stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, message);
   }
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ros::init(argc, argv, "imu_3dm_gx4");
-  ros::NodeHandle nh("~");
+  ros::NodeHandle pnh("~");
 
   std::string device;
   int baudrate;
@@ -173,34 +196,56 @@ int main(int argc, char **argv) {
   int requestedImuRate, requestedFilterRate;
   bool verbose;
   int retryAfter, maxRetries;
-  
+
   //  load parameters from launch file
-  nh.param<std::string>("device", device, "/dev/ttyACM0");
-  nh.param<int>("baudrate", baudrate, 115200);
-  nh.param<std::string>("frame_id", frameId, std::string("imu"));
-  nh.param<int>("imu_rate", requestedImuRate, 100);
-  nh.param<int>("filter_rate", requestedFilterRate, 100);
-  nh.param<bool>("enable_magnetometer", enableMagnetometer, true);
-  nh.param<bool>("enable_filter", enableFilter, false);
-  nh.param<bool>("enable_mag_update", enableMagUpdate, false);
-  nh.param<bool>("enable_accel_update", enableAccelUpdate, true);
-  nh.param<bool>("verbose", verbose, false);
-  nh.param<int>("retry_after", retryAfter, 3);
-  nh.param<int>("max_tries", maxRetries, 10);
+  pnh.param<std::string>("device", device, "/dev/ttyACM0");
+  pnh.param<int>("baudrate", baudrate, 115200);
+  pnh.param<std::string>("frame_id", frameId, "imu");
+  pnh.param<std::string>("fixed_frame_id", fixeFrameId, "world");
+  pnh.param<double>("gravity", gravity, 0.0);
+  pnh.param<int>("imu_rate", requestedImuRate, 100);
+  pnh.param<int>("filter_rate", requestedFilterRate, 100);
+  pnh.param<bool>("enable_magnetometer", enableMagnetometer, true);
+  pnh.param<bool>("enable_filter", enableFilter, false);
+  pnh.param<bool>("enable_mag_update", enableMagUpdate, false);
+  pnh.param<bool>("enable_accel_update", enableAccelUpdate, true);
+  pnh.param<bool>("enable_tf", enableTf, enableFilter);
+  pnh.param<bool>("verbose", verbose, false);
+  pnh.param<int>("retry_after", retryAfter, 3);
+  pnh.param<int>("max_tries", maxRetries, 10);
+
+  if (gravity <= 0.0) {
+    ROS_ERROR("Must set gravity value");
+    return -1;
+  } else {
+    ROS_INFO("Gravity is set to %f", gravity);
+  }
 
   if (requestedFilterRate < 0 || requestedImuRate < 0) {
     ROS_ERROR("imu_rate and filter_rate must be > 0");
     return -1;
   }
-  
-  pubIMU = nh.advertise<sensor_msgs::Imu>("imu", 1);
-  pubPressure = nh.advertise<sensor_msgs::FluidPressure>("pressure", 1);
+
+  pubIMU = pnh.advertise<sensor_msgs::Imu>("imu", 1);
+  pubPressure = pnh.advertise<sensor_msgs::FluidPressure>("pressure", 1);
+  pubGravity = pnh.advertise<std_msgs::Float64>("gravity", 1, true);
+  {
+    std_msgs::Float64 float_msg;
+    float_msg.data = gravity;
+    pubGravity.publish(float_msg);
+  }
 
   if (enableMagnetometer) {
-    pubMag = nh.advertise<sensor_msgs::MagneticField>("magnetic_field", 1);
+    pubMag = pnh.advertise<sensor_msgs::MagneticField>("magnetic_field", 1);
+    ROS_INFO("Publish magnetic field to %s", pubMag.getTopic().c_str());
   }
   if (enableFilter) {
-    pubFilter = nh.advertise<imu_3dm_gx4::FilterOutput>("filter", 1);
+    pubFilter = pnh.advertise<imu_3dm_gx4::FilterOutput>("filter", 1);
+    ROS_INFO("Publish filter to %s", pubFilter.getTopic().c_str());
+  }
+  if (enableTf) {
+    pubPose = pnh.advertise<geometry_msgs::PoseStamped>("pose", 1);
+    ROS_INFO("Publish pose to %s", pubPose.getTopic().c_str());
   }
 
   //  new instance of the IMU
@@ -216,8 +261,8 @@ int main(int argc, char **argv) {
 
       ROS_INFO("Fetching device info.");
       imu.getDeviceInfo(info);
-      std::map<std::string,std::string> map = info.toMap();
-      for (const std::pair<std::string,std::string>& p : map) {
+      std::map<std::string, std::string> map = info.toMap();
+      for (const std::pair<std::string, std::string>& p : map) {
         ROS_INFO("\t%s: %s", p.first.c_str(), p.second.c_str());
       }
 
@@ -234,11 +279,11 @@ int main(int argc, char **argv) {
       //  calculate decimation rates
       if (static_cast<uint16_t>(requestedImuRate) > imuBaseRate) {
         throw std::runtime_error("imu_rate cannot exceed " +
-                                 std::to_string(imuBaseRate));
+                                std::to_string(imuBaseRate));
       }
       if (static_cast<uint16_t>(requestedFilterRate) > filterBaseRate) {
         throw std::runtime_error("filter_rate cannot exceed " +
-                                 std::to_string(filterBaseRate));
+                                std::to_string(filterBaseRate));
       }
 
       const uint16_t imuDecimation = imuBaseRate / requestedImuRate;
@@ -248,22 +293,19 @@ int main(int argc, char **argv) {
       std::bitset<4> imuSources = Imu::IMUData::Accelerometer |
                                   Imu::IMUData::Gyroscope |
                                   Imu::IMUData::Barometer;
-      if (enableMagnetometer)
-      {
+      if (enableMagnetometer) {
         ROS_INFO("Enabling magnetometer");
         imuSources |= Imu::IMUData::Magnetometer;
-      }
-      else
-      {
+      } else {
         ROS_INFO("Disabling magnetometer");
       }
       imu.setIMUDataRate(imuDecimation, imuSources);
 
       ROS_INFO("Selecting filter decimation: %u", filterDecimation);
-      imu.setFilterDataRate(filterDecimation, Imu::FilterData::Quaternion |
-                                              Imu::FilterData::Bias |
-                                              Imu::FilterData::AngleUnertainty |
-                                              Imu::FilterData::BiasUncertainty);
+      imu.setFilterDataRate(filterDecimation,
+                            Imu::FilterData::Quaternion | Imu::FilterData::Bias |
+                                Imu::FilterData::AngleUnertainty |
+                                Imu::FilterData::BiasUncertainty);
 
       ROS_INFO("Enabling IMU data stream");
       imu.enableIMUStream(true);
@@ -285,8 +327,8 @@ int main(int argc, char **argv) {
       imu.setFilterDataCallback(publishFilter);
 
       //  configure diagnostic updater
-      if (!nh.hasParam("diagnostic_period")) {
-        nh.setParam("diagnostic_period", 0.2);  //  5hz period
+      if (!pnh.hasParam("diagnostic_period")) {
+        pnh.setParam("diagnostic_period", 0.2);  //  5hz period
       }
 
       updater.reset(new diagnostic_updater::Updater());
@@ -296,13 +338,13 @@ int main(int argc, char **argv) {
       //  calculate the actual rates we will get
       double imuRate = imuBaseRate / (1.0 * imuDecimation);
       double filterRate = filterBaseRate / (1.0 * filterDecimation);
-      imuDiag = configTopicDiagnostic("imu",&imuRate);
+      imuDiag = configTopicDiagnostic("imu", &imuRate);
       if (enableFilter) {
-        filterDiag = configTopicDiagnostic("filter",&filterRate);
+        filterDiag = configTopicDiagnostic("filter", &filterRate);
       }
 
       updater->add("diagnostic_info",
-                   boost::bind(&updateDiagnosticInfo, _1, &imu));
+                  boost::bind(&updateDiagnosticInfo, _1, &imu));
 
       ROS_INFO("Resuming the device");
       imu.resume();
@@ -312,14 +354,11 @@ int main(int argc, char **argv) {
         updater->update();
       }
       imu.disconnect();
-    }
-    catch (Imu::io_error &e) {
+    } catch (Imu::io_error& e) {
       ROS_ERROR("IO error: %s\n", e.what());
-    }
-    catch (Imu::timeout_error &e) {
+    } catch (Imu::timeout_error& e) {
       ROS_ERROR("Timeout: %s\n", e.what());
-    }
-    catch (std::exception &e) {
+    } catch (std::exception& e) {
       ROS_ERROR("Exception: %s\n", e.what());
     }
     ROS_WARN_STREAM("["<<ros::this_node::getName()<<"] Retrying in " << retryAfter << " seconds. Attempt "<<i<<"/"<<maxRetries);
@@ -328,6 +367,4 @@ int main(int argc, char **argv) {
       ros::Duration(retryAfter).sleep();
     }
   }
-
-  return 0;
 }

--- a/src/merge_imu_filter.cpp
+++ b/src/merge_imu_filter.cpp
@@ -1,0 +1,39 @@
+#include <message_filters/subscriber.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
+
+#include <sensor_msgs/Imu.h>
+#include <imu_3dm_gx4/FilterOutput.h>
+
+using namespace sensor_msgs;
+using namespace imu_3dm_gx4;
+using namespace message_filters;
+
+ros::Publisher pubMerge;
+
+void callback(const ImuConstPtr& imu, const FilterOutputConstPtr& filter)
+{
+  Imu new_imu = *imu;
+  new_imu.orientation = filter->orientation;
+  pubMerge.publish(new_imu);
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "merge_imu_filter");
+
+  ros::NodeHandle nh;
+
+  pubMerge = nh.advertise<sensor_msgs::Imu>("data", 1);
+
+  message_filters::Subscriber<Imu> imu_sub(nh, "/imu/imu", 5);
+  message_filters::Subscriber<FilterOutput> filter_sub(nh, "/imu/filter", 5);
+
+	typedef sync_policies::ApproximateTime<Imu, FilterOutput> MySyncPolicy;
+	Synchronizer<MySyncPolicy> sync(MySyncPolicy(10), imu_sub, filter_sub);
+  sync.registerCallback(boost::bind(&callback, _1, _2));
+
+  ros::spin();
+
+  return 0;
+}


### PR DESCRIPTION
Brings in several updates from upstream including melodic compatibility.

Also changes the device name in the udev rule script to `/dev/imu` instead of the default `/dev/ttyACM0` which made it difficult to set the parameter when multiple USB devices are being used.

To install the udev rule run:
`rosrun imu_3dm_gx4 add_rule`